### PR TITLE
Rework user types and examples

### DIFF
--- a/2024/survey.yaml
+++ b/2024/survey.yaml
@@ -137,29 +137,27 @@ questions:
       - I use Nix for personal projects.
       - I use Nix at work.
   - prompt: |
-      Which user types do you identify with?
+      Which user types do you identify with? Select all that apply:
     
-      - Enthusiast: You love the idea behind Nix, but don’t necessarily run NixOS as a daily driver. Maybe you spread the word among friends and coworkers. Maybe you are interested in or enthusiastic about any of the following:
+      - A. You love the idea behind Nix or NixOS. Maybe you spread the word among friends and coworkers. Maybe you are interested in or enthusiastic about any of the following:
           - Free and open source software
           - Linux
-          - Functional programming
-          - Repeatable builds
           - Home automation
           - Online communities
-      - Explorer: You’re here because you because you’re curious about Nix, how it works, and if it’s something for you. Maybe you just want to learn new things. Maybe you identify yourself as:
-          - Distro-hopper
+          - Distro-hopping
+      - B. You’re here because you’re curious about Nix and how it works. Maybe you enjoy or want to learn functional programming, or you just want to learn new things. Maybe you identify yourself as:
           - Nix-curious developer
           - Student of a technical field
           - Educator
           - Academic researcher
-      - Pragmatist: You use Nix to get things done or boost your team’s productivity, you learn Nix to grow your career opportunities, or you have to use Nix on the job because someone said so. Maybe you identify yourself as:
+      - C. You use Nix or NixOS to get things done or boost your team’s productivity, you learn it to grow your career opportunities, or you have to use it on the job because someone said so. Maybe you identify yourself as:
           - System administrator
           - Employee developer
           - DevOps engineer
           - Natural scientist
           - Open source software author
           - Early-career professional
-      - Contributor: You work or want to work on the Nix ecosystem rather than just with it. You are at least one of the following:
+      - D. You work or want to work on the Nix ecosystem rather than just with it. You are at least one of the following:
           - Aspiring contributor
           - Novice contributor
           - Drive-by contributor
@@ -167,7 +165,7 @@ questions:
           - Code owner
           - Community team member
           - Sponsor
-      - Decision-maker: You make the strategic decisions for your team or company: which technologies to adopt, which skills to train your employees in, which projects to support or invest in, which services or products to offer. Maybe you’re a:
+      - E. You make the strategic decisions for your team or company: which technologies to adopt, which skills to train your employees in, which projects to support or invest in, which services or products to offer. Maybe you’re a:
           - Entrepreneur
           - Team lead
           - Software architect
@@ -176,11 +174,11 @@ questions:
           - Public service administrator
     type: multiple
     choices:
-      - Enthusiast
-      - Explorer
-      - Pragmatist
-      - Contributor
-      - Decision-maker
+      - A
+      - B
+      - C
+      - D
+      - E
   - prompt: On which operating systems do you use Nix currently?
     type: multiple
     type: 


### PR DESCRIPTION
Based on a message I sent on Matrix, I think the "enthusiast" and "explorer" labels may be interpreted differently depending on the person, which might make them uneasy on the choices they make.
This PR focuses on removing those labels in favor of generic identifiers and reworks a few descriptions to clarify the user types more.