### PR TITLE
Force select nix or nixos on question to improve signal

### DIFF
--- a/2024/survey.yaml
+++ b/2024/survey.yaml
@@ -266,12 +266,11 @@ questions:
       please tell us what prevents it and what would help you.
     type: text
   # This year, we try to assess how people discovered Nix
-  - prompt: Did you hear about Nix or NixOS first?
+  - prompt: Did you hear about Nix or NixOS first? If you heard about both at the same time, select which one first made you interested in the Nix ecosystem.
     type: single
     choices:
       - Nix
       - NixOS
-      - both at the same time
   - prompt: How did you find out about it?
     type: single
     choices:


### PR DESCRIPTION
To quote myself on Matrix:

> The option "both at the same time" doesn't give a good enough signal of whether someone got interested specifically because of Nix or because of NixOS. I'd suggest removing that option and adding perhaps a disclaimer that if the user heard about both at the same time, to pick the option that interested them in the ecosystem in the first place.

> It will definitely change the intention of the question though, and as a disclaimer I don't know what was the intention behind the question in the first place, but to me I'd use it as a way of understanding which one of those options got people interested in the nix ecosystem in the first place.